### PR TITLE
Clock initialisation

### DIFF
--- a/max31855.py
+++ b/max31855.py
@@ -35,6 +35,9 @@ class MAX31855(object):
         # Pull chip select high to make chip inactive
         GPIO.output(self.cs_pin, GPIO.HIGH)
 
+        # Initialise clock low
+        GPIO.output(self.clock_pin, GPIO.LOW)
+
     def get(self):
         '''Reads SPI bus and returns current value of thermocouple.'''
         self.read()


### PR DESCRIPTION
Added initialisation of clock to low state. Without this, the use of a pin with a default pull-up results in erroneously clocking out the first bit and all bits being offset by one.